### PR TITLE
Fix: EntityMetadataWrapper exception when NOT using billing address 

### DIFF
--- a/commerce_dotpay.module
+++ b/commerce_dotpay.module
@@ -345,15 +345,18 @@ function commerce_dotpay_order_form($form, $form_state, $order, $payment_method)
 		'type' => DOTPAY_PAYMENT_TYPE,
 		'api_version' => DOTPAY_API_VERSION,
 		// below additional optional parameters
+		'email'	=> $order->mail,
+	);
+	
+	if (isset($wrapper->commerce_customer_billing) && isset($wrapper->commerce_customer_billing->commerce_customer_address)) {
+	    $data += array(
 		'firstname' => $wrapper->commerce_customer_billing->commerce_customer_address->first_name->value(),
 		'lastname' => $wrapper->commerce_customer_billing->commerce_customer_address->first_name->value(),
-		'email'	=> $order->mail,
 		'city'	=> $wrapper->commerce_customer_billing->commerce_customer_address->locality->value(),
 		'postcode' => $wrapper->commerce_customer_billing->commerce_customer_address->postal_code->value(),
 		'country' => $wrapper->commerce_customer_billing->commerce_customer_address->country->value(),
-	);
-
-
+	    );
+	}
 
 	foreach ($data as $name => $value) {
 		$form[$name] = array(


### PR DESCRIPTION
We are not using billing address in our flow. In our configuration, Dotpay module causes exception in Entity. 
