### PR TITLE
Fix: index only first 200 bytes of image to avoid invalid key error 

### DIFF
--- a/include/CardBrand.php
+++ b/include/CardBrand.php
@@ -38,7 +38,7 @@ class CardBrand {
                     `name` varchar(20) DEFAULT NULL,
                     `image` varchar(170) DEFAULT NULL,
                     PRIMARY KEY (`name`),
-                    UNIQUE KEY `brand_img` (`image`)
+                    UNIQUE KEY `brand_img` (`image`(200))
                 ) DEFAULT CHARSET=utf8;';
         db_query($sql);
     }


### PR DESCRIPTION
To close #3 you should also trim brand_img to 200 bytes in the key.