### PR TITLE
Add permission to manage users' own saved cards

### DIFF
--- a/commerce_dotpay_main.php
+++ b/commerce_dotpay_main.php
@@ -49,6 +49,20 @@ function commerce_dotpay_commerce_payment_method_info() {
 }
 
 /**
+ * Implementation of hook_permission()
+ *
+ * Define permissions used in this module.
+ */
+
+function commerce_dotpay_permission() {
+    return array(
+        'access dotpay ocmanage' => array(
+            'title' => t('Manage own saved cards'),
+            'description' => t('Allows users to access their saved cards management interface at /user/[uid]/ocmanage'),
+        ),
+    );
+}
+/**
  * Implementation of hook_settings_form()
  * Returns data for Drupal API Forms with form of plugin settings
  * @param array|null $settings
@@ -124,7 +138,7 @@ function commerce_dotpay_menu() {
         'page callback' => 'commerce_dotpay_ocmanage',
         'page arguments' => array(1),
         'type' => MENU_LOCAL_TASK,
-        'access callback' => true,
+        'access arguments' => array('access dotpay ocmanage'),
         'weight' => 20,
     );
     $items['dotpay/oc/remove'] = array(


### PR DESCRIPTION
I need a permission that will help us control which users can see "ocmanage" page on their profile. This pull request implements this.